### PR TITLE
remove entrypoint subdomain

### DIFF
--- a/inventory_example/group_vars/all.yml
+++ b/inventory_example/group_vars/all.yml
@@ -29,7 +29,7 @@ local:
 
 cluster:
   environment: "{{ host.cluster_environment }}"
-  entrypoint: "entrypoint.{{ host.cluster_environment }}.solana.com"
+  entrypoint: "{{ host.cluster_environment }}.solana.com"
   rpc_address: "{{ host.cluster_rpc_address }}"
 
 node:


### PR DESCRIPTION
on v1.6.8 with 
`--entrypoint entrypoint.testnet.solana.com:8001`
error on first run:
`Waiting to adopt entrypoint shred version...`

Set
`--entrypoint testnet.solana.com:8001`
fix it