### PR TITLE
bugfix

### DIFF
--- a/roles/solana_config/tasks/main.yaml
+++ b/roles/solana_config/tasks/main.yaml
@@ -11,6 +11,16 @@
     path: /etc/sv_manager/sv_manager.conf
   register: config_exists
 
+- name: ensure secrets_path exists
+  stat:
+    path: "{{ secrets_path }}"
+  register: secrets_path_exists
+
+- name: reset secrets path
+  set_fact:
+    secrets_path: "{{ local_secrets_path }}"
+  when: not secrets_path_exists.stat.exists
+
 - name: Load config file
   slurp:
     src: /etc/sv_manager/sv_manager.conf


### PR DESCRIPTION
When user installs monitoring only, validator keys are not copied to secrets_path.
Now, if secrets_path does not exists (=sv_manager not used) local_secrets_path is used instead.