### PR TITLE
Adding rsyslog

### DIFF
--- a/roles/configure_ubuntu/tasks/packages.yaml
+++ b/roles/configure_ubuntu/tasks/packages.yaml
@@ -20,5 +20,6 @@
       - python3
       - python3-pip
       - ufw
+      - rsyslog
   tags:
     - config.packages


### PR DESCRIPTION
Sometimes this package is not installed by default and it's needed because solana is added to syslog group (which will not exist without this package).