### PR TITLE
Update versions mainnet to 1.10.39 and testnet to 1.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That's it, you are all set!
 ### How to update validator
 
 ````shell
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mfactory-lab/sv-manager/latest/install/update_test_validator_version.sh)" --version 1.10.19
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mfactory-lab/sv-manager/latest/install/update_test_validator_version.sh)" --version 1.14.2
 ````
 
 ### how to update monitoring

--- a/inventory_example/group_vars/mainnet_validators.yaml
+++ b/inventory_example/group_vars/mainnet_validators.yaml
@@ -20,6 +20,6 @@ expected_genesis_hash: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
 limit_ledger_size: 50000000
 snapshot_interval_slots: 2000
 maximum_local_snapshot_age: 3000
-solana_version: 1.10.38
+solana_version: 1.10.39
 extra_params:
   - '--incremental-snapshot-interval-slots 200'

--- a/inventory_example/group_vars/testnet_validators.yaml
+++ b/inventory_example/group_vars/testnet_validators.yaml
@@ -18,6 +18,6 @@ expected_genesis_hash: '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY'
 limit_ledger_size: 50000000
 snapshot_interval_slots: 500
 maximum_local_snapshot_age: 1000
-solana_version: 1.11.10
+solana_version: 1.14.2
 extra_params:
   - '--incremental-snapshot-interval-slots 200'


### PR DESCRIPTION
The Mainnet-Beta minimum software version is now 1.10.39. This will take effect starting in Mainnet-Beta epoch 352.

Testnet minimum software version is now 1.14.2. This will take effect starting in Testnet epoch 365

@AlexanderRay @Rossignolskier 