### PR TITLE
Disable ondemand service

### DIFF
--- a/roles/configure_ubuntu/tasks/cpu_governor.yaml
+++ b/roles/configure_ubuntu/tasks/cpu_governor.yaml
@@ -13,3 +13,11 @@
   tags:
     config.cpu
   when: scaling_governor_exists.stat.exists
+  
+- name: Disable ondemand service
+  systemd:
+    name: ondemand
+    state: stopped
+    enabled: no
+  tags:
+    - config.cpu


### PR DESCRIPTION
It prevents the on-demand service from resetting performance mode on reboot.