### PR TITLE
Add Salt Lake City to Jito config

### DIFF
--- a/inventory_example/group_vars/mainnet_validators.yaml
+++ b/inventory_example/group_vars/mainnet_validators.yaml
@@ -44,3 +44,7 @@ jito_urls:
     block_engine: "https://tokyo.mainnet.block-engine.jito.wtf"
     relayer: "http://tokyo.mainnet.relayer.jito.wtf:8100"
     shred_receiver_addr: "202.8.9.160:1002"
+  saltlakecity:
+    block_engine: "https://slc.mainnet.block-engine.jito.wtf"
+    relayer: "http://slc.mainnet.relayer.jito.wtf:8100"
+    shred_receiver_addr: "64.130.53.8:1002"


### PR DESCRIPTION
New location for lower latency added to Mainnet-Beta.

See info here:
https://jito-labs.gitbook.io/mev/searcher-resources/block-engine/mainnet-addresses